### PR TITLE
feat: add opencode AI coding agent

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -46,6 +46,9 @@ cask "ghostty"  # Fast, native terminal emulator
 # Text Editors & IDEs
 cask "sublime-text"  # Sophisticated text editor for code, markup and prose
 
+# AI Coding Agents
+brew "anomalyco/tap/opencode"  # Open source AI coding agent (TUI)
+
 # Productivity Apps
 cask "notion"    # All-in-one workspace for notes and collaboration
 cask "obsidian"  # Knowledge base and note-taking with markdown

--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,7 @@ DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DOTFILES_DIR"
 
 # Stow each package
-for package in zsh tmux starship ghostty aerospace sublime-text; do
+for package in zsh tmux starship ghostty aerospace sublime-text opencode; do
     if [ -d "$package" ]; then
         stow -t "$HOME" "$package" 2>&1 | grep -v "BUG in find_stowed_path" || true
         print_success "Stowed $package"

--- a/opencode/.config/opencode/opencode.json
+++ b/opencode/.config/opencode/opencode.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "anthropic/claude-opus-4-7",
+  "autoupdate": true
+}


### PR DESCRIPTION
Adds opencode (anomalyco/opencode) via Homebrew tap with stow-managed config defaulting to claude-opus-4-7.